### PR TITLE
Demo showing spec 404 error

### DIFF
--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -142,7 +142,7 @@ export default {
         me.loading=true;
         ProcessSpec(jsonObj).then(function( spec ){
           me.loading=false;
-          me.specUrl="https://api.apis.guru/v2/specs/bitbucket.org/2.0/swagger.json";
+          me.specUrl="https://api.apis.guru/v2/specs/bitbucket.org/2.0/openapi.json";
           me.showLoadJsonPanel=false;
           me.afterSpecParsedAndValidated(spec);
         })


### PR DESCRIPTION
Might be worth setting up some tests to make sure the demo can load the default spec, or perhaps host one yourself so you aren't breaking when a third party changes something. Either way, this'll get you up and running for now.